### PR TITLE
Add Google Analytics tracking ID to yml configuration

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -9,9 +9,9 @@ on:
     branches: [ main, staging ]
     paths:
       - '*.qmd'
-      - '*.Rmd'
       - assets/*
       - quizzes/*
+      - '*.yml'
 
 jobs:
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -12,6 +12,7 @@ book:
   repo-url: https://github.com/ottrproject/OTTR_Quarto
   repo-actions: [edit] 
   issue-url: https://docs.google.com/forms/d/e/1FAIpQLSfBvVELBg8lcynKj0TrzMlov1zil-Sbkh9VhMKRcSpeo1xo6g/viewform
+  google-analytics: "G-XXXXXXXXXX"
   
   chapters:
     - index.qmd


### PR DESCRIPTION
(1) Quarto google analytics integration doesn't use an html or Rhtml file, so adding the google analytics tracking ID option to the _quarto.yml option and (2) updating the triggers for render all to sync with the original template, but be specific to the quarto flavor.